### PR TITLE
fixing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Change `config.ini` to include your username & login from MySportsFeeds.com
 Set storage location of API feeds (default is `results/`)
 
     [FileStore]
-    location <your results location>
+    location: <your results location>
     
 Install requirements and run tests
 


### PR DESCRIPTION
documentation was missing a colon in the FileStore stanza for the location parameter